### PR TITLE
update test to expect more then 6 files to reflect current repo size

### DIFF
--- a/.learn
+++ b/.learn
@@ -7,3 +7,4 @@ tags:
   - tutorial
 languages:
   - bash
+resources:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You should see something like: `/Users/avi/first-lab-000`
 
 ![1](https://dl.dropboxusercontent.com/s/4h2yls40mf9femj/2015-05-03%20at%209.05%20PM.png)
 
-Now, try to run the `learn` CLI by typing `learn` in the lesson's directory. You'll see output similar to this, with failing tests (that's fine, don't panic).
+Now, try to run the `learn` CLI by typing `learn` in the lesson's directory. You'll see output *similar* to this, with failing tests (that's fine, don't panic).
 
 ![Failing Tests](https://dl.dropboxusercontent.com/s/9ob3cey1lpeb6ql/2015-05-03%20at%209.10%20PM.png)
 

--- a/spec/lab_spec.rb
+++ b/spec/lab_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 describe 'First Lab' do
   it 'added a file' do
-    expect(Dir["*"].size).to be > 3
+    expect(Dir["*"].size).to be > 6
   end
 end


### PR DESCRIPTION
The spec is testing that the user created a file by expecting the current size of the directory to be more then 3 (presumably the size of this repo at one point). This increases the test to ensure it's more then 6, to reflect the current size of the repo. fixes #23 
@AnnJohn @PeterBell 